### PR TITLE
Update po4a to v0.66-mod1

### DIFF
--- a/bin/setup-build-env
+++ b/bin/setup-build-env
@@ -13,4 +13,4 @@ sudo pip3 install translate-toolkit Python-Levenshtein
 sudo gem install bundler
 sudo npm --global install surge
 
-git clone https://github.com/doc-l10n-kit/po4a.git vendor/po4a -b 0.58.1-mod
+git clone https://github.com/doc-l10n-kit/po4a.git vendor/po4a -b v0.66-mod1


### PR DESCRIPTION
This change enables Asciidoc yaml frontmatter(https://jekyllrb.com/docs/front-matter/) parse, which is used for blog posts metadata.