### PR TITLE
Update quarkus-l10n-utils to 0.5.3

### DIFF
--- a/config/l10n-utils.json
+++ b/config/l10n-utils.json
@@ -16,7 +16,7 @@
     "version": "0.9.5.RELEASE"
   },
   "doc-l10n-utils":{
-    "version": "0.5.2"
+    "version": "0.5.3"
   },
   "po4a":{
     "branch": "v0.66-mod1"


### PR DESCRIPTION
to address quarkusio.github.io repository default branch name change
Ref. https://github.com/quarkusio/quarkusio.github.io/issues/1952