### PR TITLE
Bump doc-l10n-kit to 0.9.6.RELEASE

### DIFF
--- a/config/l10n-utils.json
+++ b/config/l10n-utils.json
@@ -13,7 +13,7 @@
     }
   },
   "doc-l10n-kit":{
-    "version": "0.9.5.RELEASE"
+    "version": "0.9.6.RELEASE"
   },
   "doc-l10n-utils":{
     "version": "0.5.3"


### PR DESCRIPTION
to address issues caused by quarkus 3.15 site changes