### PR TITLE
Update GitHub actions versions (actions/cache in particular)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,12 +24,12 @@ jobs:
     steps:
       - name: Checkout
         # Checkout target revision from git repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
         with:
           fetch-depth: 0 # all history (required for getting last modified time of files)
       - name: Cache bundle directory
         # Cache ruby bundle directory to speed up build
-        uses: actions/cache@v3
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # 4.2.3
         with:
           path: vendor/bundle
           key: ${{ runner.os }}-gem-${{ hashFiles('**/Gemfile.lock') }}
@@ -91,10 +91,10 @@ jobs:
     steps:
       - name: Checkout
         # Checkout target revision from git repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
       - name: Cache bundle directory
         # Cache ruby bundle directory to speed up build
-        uses: actions/cache@v2
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # 4.2.3
         with:
           path: vendor/bundle
           key: ${{ runner.os }}-gem-${{ hashFiles('**/Gemfile.lock') }}

--- a/.github/workflows/create-glossary.yml
+++ b/.github/workflows/create-glossary.yml
@@ -10,12 +10,12 @@ jobs:
     steps:
       - name: Checkout
         # Checkout target revision from git repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
         with:
           fetch-depth: 0 # all history (required for getting last modified time of files)
       - name: Cache bundle directory
         # Cache ruby bundle directory to speed up build
-        uses: actions/cache@v3
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # 4.2.3
         with:
           path: vendor/bundle
           key: ${{ runner.os }}-gem-${{ hashFiles('**/Gemfile.lock') }}

--- a/.github/workflows/delete-glossary.yml
+++ b/.github/workflows/delete-glossary.yml
@@ -14,12 +14,12 @@ jobs:
     steps:
       - name: Checkout
         # Checkout target revision from git repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
         with:
           fetch-depth: 0 # all history (required for getting last modified time of files)
       - name: Cache bundle directory
         # Cache ruby bundle directory to speed up build
-        uses: actions/cache@v3
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # 4.2.3
         with:
           path: vendor/bundle
           key: ${{ runner.os }}-gem-${{ hashFiles('**/Gemfile.lock') }}

--- a/.github/workflows/list-glossaries.yml
+++ b/.github/workflows/list-glossaries.yml
@@ -10,12 +10,12 @@ jobs:
     steps:
       - name: Checkout
         # Checkout target revision from git repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
         with:
           fetch-depth: 0 # all history (required for getting last modified time of files)
       - name: Cache bundle directory
         # Cache ruby bundle directory to speed up build
-        uses: actions/cache@v3
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # 4.2.3
         with:
           path: vendor/bundle
           key: ${{ runner.os }}-gem-${{ hashFiles('**/Gemfile.lock') }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -9,10 +9,10 @@ jobs:
     steps:
       - name: Checkout base branch
         # To avoid GitHub Secrets compromise, checkout base branch to get reliable (untainted) build scripts
-        uses: actions/checkout@v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
       - name: Checkout merged commit to 'merged' dir
         # Checkout merged commit to 'merged' dir
-        uses: actions/checkout@v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           path: merged
@@ -23,7 +23,7 @@ jobs:
           cp -r merged/l10n ./
       - name: Cache bundle directory
         # Cache ruby bundle directory to speed up build
-        uses: actions/cache@v3
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # 4.2.3
         with:
           path: vendor/bundle
           key: ${{ runner.os }}-gem-${{ hashFiles('**/Gemfile.lock') }}
@@ -45,7 +45,7 @@ jobs:
           SURGE_TOKEN: ${{ secrets.SURGE_TOKEN }}
       - name: Add comment
         # Add comment to the pull request to announce the deployed preview site URL.
-        uses: actions/github-script@v3.1.0
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # 7.0.1
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -13,14 +13,14 @@ jobs:
     steps:
       - name: Checkout
         # Checkout target revision from git repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # 4.2.2
       - name: Setup build env
         # Setup build environment(install runtime, library, etc.)
         run: |
           bin/setup-build-env-on-ubuntu
       - name: Set up JDK 11
         # Setup JDK 11
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # 4.7.1
         with:
           distribution: 'temurin'
           java-version: 11


### PR DESCRIPTION
since actions/cache v2 is disallowed and would fail the build if used. While at it, applied the use of hashes instead of version tags.