### PR TITLE
Update Spanish translation for Kafka Streams guide.

### DIFF
--- a/l10n/po/es_ES/_guides/kafka-streams.adoc.po
+++ b/l10n/po/es_ES/_guides/kafka-streams.adoc.po
@@ -6,30 +6,30 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: PACKAGE VERSION\n"
+"Project-Id-Version: \n"
 "POT-Creation-Date: 2023-10-29 08:10+0000\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE <LL@li.org>\n"
+"PO-Revision-Date: 2025-10-11 07:35-0500\n"
+"Last-Translator: William Hincapie <daemonsoft@gmail.com>\n"
+"Language-Team: \n"
 "Language: es_ES\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 3.7\n"
 
 #. This guide is maintained in the main Quarkus repository
 #. and pull requests should be submitted there:
 #. https://github.com/quarkusio/quarkus/tree/main/docs/src/main/asciidoc
 #. type: Title =
 #: _guides/kafka-streams.adoc
-#, fuzzy, no-wrap
+#, no-wrap
 msgid "Using Apache Kafka Streams"
-msgstr "Uso de Apache Kafka Streams"
+msgstr "Usando Apache Kafka Streams"
 
 #. type: Plain text
 #: _guides/kafka-streams.adoc
-#, fuzzy
 msgid "This guide demonstrates how your Quarkus application can utilize the Apache Kafka Streams API to implement stream processing applications based on Apache Kafka."
-msgstr "Esta guía demuestra cómo su aplicación Quarkus puede utilizar la API Apache Kafka Streams para implementar aplicaciones de procesamiento de flujos basadas en Apache Kafka."
+msgstr "Esta guía demuestra cómo su aplicación Quarkus puede utilizar la API de Apache Kafka Streams para implementar aplicaciones de procesamiento de flujos basadas en Apache Kafka."
 
 #. type: Title ==
 #: _guides/kafka-streams.adoc
@@ -39,41 +39,39 @@ msgstr "Requisitos previos"
 
 #. type: Plain text
 #: _guides/kafka-streams.adoc
-#, fuzzy
 msgid "It is recommended, that you have read the link:{quickstarts-tree-url}/kafka-quickstart[Kafka quickstart] before."
-msgstr "Se recomienda haber leído antes el {quickstarts-tree-url}/kafka-quickstart[Kafka quickstart]."
+msgstr "Se recomienda haber leído antes el enlace {quickstarts-tree-url}/kafka-quickstart[Kafka quickstart]."
 
 #: _guides/kafka-streams.adoc
-#, fuzzy
 msgid ""
 "The Quarkus extension for Kafka Streams allows for very fast turnaround times during development by supporting the Quarkus Dev Mode (e.g. via `./mvnw quarkus:dev`).\n"
 "After changing the code of your Kafka Streams topology, the application will automatically be reloaded when the next input message arrives."
-msgstr "La extensión de Quarkus para Kafka Streams permite tiempos de respuesta muy rápidos durante el desarrollo al soportar el Quarkus Dev Mode (por ejemplo, a través de `./mvnw quarkus:dev` ). Tras cambiar el código de su topología Kafka Streams, la aplicación se recargará automáticamente cuando llegue el siguiente mensaje de entrada."
+msgstr ""
+"La extensión de Quarkus para Kafka Streams permite ciclos de desarrollo muy rápidos al admitir el Modo de Desarrollo de Quarkus (por ejemplo, mediante `./mvnw quarkus:dev`).\n"
+"Después de modificar el código de la topología de Kafka Streams, la aplicación se recargará automáticamente cuando llegue el siguiente mensaje de entrada."
 
 #: _guides/kafka-streams.adoc
-#, fuzzy
 msgid ""
 "A recommended development set-up is to have some producer which creates test messages on the processed topic(s) in fixed intervals, e.g. every second and observe the streaming application's output topic(s) using a tool such as `kafkacat`.\n"
 "Using the dev mode, you'll instantly see messages on the output topic(s) as produced by the latest version of your streaming application when saving."
-msgstr "Una configuración de desarrollo recomendada es disponer de algún productor que cree mensajes de prueba en el tema o temas procesados en intervalos fijos, por ejemplo, cada segundo, y observar el tema o temas de salida de la aplicación de streaming utilizando una herramienta como `kafkacat` . Utilizando el modo dev, verá instantáneamente los mensajes en el tema(s) de salida tal y como los produce la última versión de su aplicación de streaming al guardar."
+msgstr ""
+"Una configuración de desarrollo recomendada es contar con un productor que genere mensajes de prueba en los tópicos procesados a intervalos fijos, por ejemplo cada segundo, y observar los mensajes en los tópicos de salida de la aplicación de streaming utilizando una herramienta como `kafkacat`.\n"
+"Con el modo de desarrollo, verá al instante los mensajes en los tópicos de salida tal como los produce la última versión de su aplicación de streaming al guardar los cambios."
 
 #. type: delimited block =
 #: _guides/kafka-streams.adoc
-#, fuzzy
 msgid "For the best development experience, we recommend applying the following configuration settings to your Kafka broker:"
-msgstr "Para obtener la mejor experiencia de desarrollo, recomendamos aplicar los siguientes ajustes de configuración a su corredor Kafka:"
+msgstr "Para obtener la mejor experiencia de desarrollo, recomendamos aplicar las siguientes configuraciones a su corredor de Kafka:"
 
 #. type: Plain text
 #: _guides/kafka-streams.adoc
-#, fuzzy
 msgid "Also specify the following settings in your Quarkus `application.properties`:"
-msgstr "Especifique también los siguientes ajustes en su Quarkus `application.properties`:"
+msgstr "Especifique también las siguientes configuraciones en su archivo `application.properties` de Quarkus:"
 
 #. type: Plain text
 #: _guides/kafka-streams.adoc
-#, fuzzy
 msgid "Together, these settings will ensure that the application can very quickly reconnect to the broker after being restarted in dev mode."
-msgstr "Juntos, estos ajustes asegurarán que la aplicación pueda reconectarse muy rápidamente al broker después de ser reiniciada en modo dev."
+msgstr "En conjunto, estas configuraciones garantizarán que la aplicación pueda reconectarse muy rápidamente al corredor después de reiniciarse en el Modo de Desarrollo."
 
 #. type: Named 'alt' AttributeList argument for macro 'image'
 #: _guides/kafka-streams.adoc
@@ -82,48 +80,46 @@ msgid "Architecture"
 msgstr "Arquitectura"
 
 #: _guides/kafka-streams.adoc
-#, fuzzy
 msgid ""
 "In this guide, we are going to generate (random) temperature values in one component (named `generator`).\n"
 "These values are associated to given weather stations and are written in a Kafka topic (`temperature-values`).\n"
 "Another topic (`weather-stations`) contains just the main data about the weather stations themselves (id and name)."
-msgstr "En esta guía, vamos a generar valores de temperatura (aleatorios) en un componente (denominado `generator` ). Estos valores están asociados a estaciones meteorológicas determinadas y se escriben en un tema Kafka ( `temperature-values` ). Otro tema ( `weather-stations` ) contiene sólo los datos principales sobre las propias estaciones meteorológicas (id y nombre)."
+msgstr ""
+"En esta guía, vamos a generar valores de temperatura (aleatorios) en un componente llamado `generator`.\n"
+"Estos valores están asociados a determinadas estaciones meteorológicas y se escriben en un tópico de Kafka ( `temperature-values` ).\n"
+"Otro tópico (`weather-stations`) contiene únicamente los datos principales de las estaciones meteorológicas (id y nombre)."
 
 #. type: delimited block =
 #: _guides/kafka-streams.adoc
-#, fuzzy
 msgid "A second component (`aggregator`) reads from the two Kafka topics and processes them in a streaming pipeline:"
-msgstr "Un segundo componente ( `aggregator`) lee de los dos temas de Kafka y los procesa en una canalización de flujo:"
+msgstr "Un segundo componente (`aggregator`) lee de los dos tópicos de Kafka y los procesa en un flujo de streaming:"
 
 #. type: delimited block =
 #: _guides/kafka-streams.adoc
-#, fuzzy
 msgid "the two topics are joined on weather station id"
-msgstr "los dos temas se unen en la identificación de la estación meteorológica"
+msgstr "los dos tópicos se combinan según el ID de la estación meteorológica"
 
 #. type: delimited block =
 #: _guides/kafka-streams.adoc
-#, fuzzy
 msgid "per weather station the min, max and average temperature is determined"
-msgstr "por estación meteorológica se determina la temperatura mínima, máxima y media"
+msgstr "para cada estación meteorológica se determinan la temperatura mínima, máxima y promedio"
 
 #. type: delimited block =
 #: _guides/kafka-streams.adoc
-#, fuzzy
 msgid "this aggregated data is written out to a third topic (`temperatures-aggregated`)"
-msgstr "estos datos agregados se escriben en un tercer tema ( `temperatures-aggregated`)"
+msgstr "estos datos agregados se escriben en un tercer tópico ( `temperatures-aggregated`)"
 
 #: _guides/kafka-streams.adoc
-#, fuzzy
 msgid ""
 "The data can be examined by inspecting the output topic.\n"
 "By exposing a Kafka Streams https://kafka.apache.org/22/documentation/streams/developer-guide/interactive-queries.html[interactive query],\n"
 "the latest result for each weather station can alternatively be obtained via a simple REST query."
-msgstr "Los datos pueden examinarse inspeccionando el tema de salida. Mediante la exposición de una link:https://kafka.apache.org/22/documentation/streams/developer-guide/interactive-queries.html[consulta interactiva] Kafka Streams, el último resultado de cada estación meteorológica puede obtenerse alternativamente a través de una simple consulta REST."
+msgstr ""
+"Los datos pueden examinarse inspeccionando el tópico de salida.\n"
+"Mediante la exposición de una link:https://kafka.apache.org/22/documentation/streams/developer-guide/interactive-queries.html[consulta interactiva] de Kafka Streams, el último resultado de cada estación meteorológica puede obtenerse alternativamente a través de una sencilla consulta REST."
 
 #. type: delimited block =
 #: _guides/kafka-streams.adoc
-#, fuzzy
 msgid "The overall architecture looks like so:"
 msgstr "La arquitectura general se ve así:"
 
@@ -134,11 +130,12 @@ msgid "Solution"
 msgstr "Solución"
 
 #: _guides/kafka-streams.adoc
-#, fuzzy
 msgid ""
 "We recommend that you follow the instructions in the next sections and create the application step by step.\n"
 "However, you can go right to the completed example."
-msgstr "Le recomendamos que siga las instrucciones de las siguientes secciones y cree la aplicación paso a paso. Sin embargo, puede ir directamente al ejemplo completado."
+msgstr ""
+"Recomendamos que siga las instrucciones de las siguientes secciones y cree la aplicación paso a paso.\n"
+"Sin embargo, también puede ir directamente al ejemplo completo."
 
 #. type: delimited block =
 #: _guides/kafka-streams.adoc
@@ -147,35 +144,35 @@ msgstr "Clone el repositorio Git: `git clone {quickstarts-clone-url}` o descargu
 
 #. type: delimited block =
 #: _guides/kafka-streams.adoc
-#, fuzzy
 msgid "The solution is located in the `kafka-streams-quickstart` link:{quickstarts-tree-url}/kafka-streams-quickstart[directory]."
-msgstr "La solución se encuentra en `kafka-streams-quickstart` {quickstarts-tree-url}/kafka-streams-quickstart[directorio]."
+msgstr "La solución se encuentra en el directorio link:{quickstarts-tree-url}[`kafka-streams-quickstart`]."
 
 #. type: Title ==
 #: _guides/kafka-streams.adoc
-#, fuzzy, no-wrap
+#, no-wrap
 msgid "Creating the Producer Maven Project"
 msgstr "Creación del proyecto Maven del productor"
 
 #: _guides/kafka-streams.adoc
-#, fuzzy
 msgid ""
 "First, we need a new project with the temperature value producer.\n"
 "Create a new project with the following command:"
-msgstr "En primer lugar, necesitamos un nuevo proyecto con el productor de valores de temperatura. Cree un nuevo proyecto con el siguiente comando:"
+msgstr ""
+"Primero, necesitamos un nuevo proyecto con el productor de valores de temperatura.\n"
+"Cree un nuevo proyecto con el siguiente comando:"
 
 #. type: delimited block =
 #: _guides/kafka-streams.adoc
-#, fuzzy
 msgid "This command generates a Maven project, importing the Reactive Messaging and Kafka connector extensions."
-msgstr "Este comando genera un proyecto Maven, importando las extensiones de Reactive Messaging y Kafka connector."
+msgstr "Este comando genera un proyecto Maven, importando las extensiones de Mensajería Reactiva y el conector de Kafka."
 
 #: _guides/kafka-streams.adoc
-#, fuzzy
 msgid ""
 "If you already have your Quarkus project configured, you can add the `messaging-kafka` extension\n"
 "to your project by running the following command in your project base directory:"
-msgstr "Si ya tiene configurado su proyecto Quarkus, puede añadir la extensión `messaging-kafka` a su proyecto ejecutando el siguiente comando en el directorio base de su proyecto:"
+msgstr ""
+"Si ya tiene configurado su proyecto Quarkus, puede añadir la extensión `messaging-kafka`\n"
+"a su proyecto ejecutando el siguiente comando en el directorio base de su proyecto:"
 
 #. type: delimited block =
 #: _guides/kafka-streams.adoc
@@ -196,291 +193,294 @@ msgstr "build.gradle"
 
 #. type: Title ===
 #: _guides/kafka-streams.adoc
-#, fuzzy, no-wrap
+#, no-wrap
 msgid "The Temperature Value Producer"
 msgstr "El productor de valores de temperatura"
 
 #: _guides/kafka-streams.adoc
-#, fuzzy
 msgid ""
 "Create the `producer/src/main/java/org/acme/kafka/streams/producer/generator/ValuesGenerator.java` file,\n"
 "with the following content:"
-msgstr "Cree el archivo `producer/src/main/java/org/acme/kafka/streams/producer/generator/ValuesGenerator.java` , con el siguiente contenido:"
+msgstr ""
+"Cree el archivo `producer/src/main/java/org/acme/kafka/streams/producer/generator/ValuesGenerator.java`,\n"
+"con el siguiente contenido:"
 
 #. type: Plain text
 #: _guides/kafka-streams.adoc
-#, fuzzy
 msgid "Instruct Reactive Messaging to dispatch the items from the returned `Multi` to `temperature-values`."
 msgstr "Indique a Mensajería Reactiva que envíe los elementos de la `Multi` devuelta a `temperature-values`."
 
 #. type: Plain text
 #: _guides/kafka-streams.adoc
-#, fuzzy
 msgid "The method returns a Mutiny _stream_ (`Multi`) emitting a random temperature value every 0.5 seconds."
 msgstr "El método devuelve un _flujo_ Mutiny ( `Multi`) que emite un valor de temperatura aleatorio cada 0,5 segundos."
 
 #. type: Plain text
 #: _guides/kafka-streams.adoc
-#, fuzzy
 msgid "Instruct Reactive Messaging to dispatch the items from the returned `Multi` (static list of weather stations) to `weather-stations`."
-msgstr "Indique a Reactive Messaging que envíe los elementos del `Multi` devuelto (lista estática de estaciones meteorológicas) a `weather-stations`."
+msgstr "Indique a Mensajería Reactiva que envíe los elementos de la `Multi` devuelta (lista estática de estaciones meteorológicas) a `weather-stations`."
 
 #. type: Plain text
 #: _guides/kafka-streams.adoc
-#, fuzzy
 msgid "The two methods each return a _reactive stream_ whose items are sent to the streams named `temperature-values` and `weather-stations`, respectively."
 msgstr "Ambos métodos devuelven un _flujo reactivo_ cuyos elementos se envían a los flujos denominados `temperature-values` y `weather-stations`, respectivamente."
 
 #. type: Title ===
 #: _guides/kafka-streams.adoc
-#, fuzzy, no-wrap
+#, no-wrap
 msgid "Topic Configuration"
-msgstr "Configuración de los temas"
+msgstr "Configuración de los tópicos"
 
 #: _guides/kafka-streams.adoc
-#, fuzzy
 msgid ""
 "The two channels are mapped to Kafka topics using the Quarkus configuration file `application.properties`.\n"
 "For that, add the following to the file `producer/src/main/resources/application.properties`:"
-msgstr "Los dos canales se asignan a temas de Kafka utilizando el archivo de configuración de Quarkus `application.properties` . Para ello, añada lo siguiente al archivo `producer/src/main/resources/application.properties` :"
+msgstr ""
+"Los dos canales se asignan a tópicos de Kafka utilizando el archivo de configuración de Quarkus `application.properties`. \n"
+"Para ello, agregue lo siguiente al archivo `producer/src/main/resources/application.properties`:"
 
 #: _guides/kafka-streams.adoc
-#, fuzzy
 msgid ""
 "This configures the Kafka bootstrap server, the two topics and the corresponding (de-)serializers.\n"
 "More details about the different configuration options are available on the https://kafka.apache.org/documentation/#producerconfigs[Producer configuration] and https://kafka.apache.org/documentation/#consumerconfigs[Consumer configuration] section from the Kafka documentation."
-msgstr "Esto configura el servidor de arranque de Kafka, los dos temas y los (des)serializadores correspondientes. Encontrará más detalles sobre las distintas opciones de configuración en la sección link:https://kafka.apache.org/documentation/#producerconfigs[Configuración del productor] y link:https://kafka.apache.org/documentation/#consumerconfigs[Configuración del consumidor] de la documentación de Kafka."
+msgstr ""
+"Esta configuración define el servidor bootstrap de Kafka, los dos tópicos y los (de)serializadores correspondientes. \n"
+"Más detalles sobre las diferentes opciones de configuración están disponibles en la documentación de Kafka, en las secciones https://kafka.apache.org/documentation/#producerconfigs[Configuración del productor] y https://kafka.apache.org/documentation/#consumerconfigs[Configuración del consumidor]."
 
 #. type: Title ==
 #: _guides/kafka-streams.adoc
-#, fuzzy, no-wrap
+#, no-wrap
 msgid "Creating the Aggregator Maven Project"
 msgstr "Creación del proyecto Maven del agregador"
 
 #: _guides/kafka-streams.adoc
-#, fuzzy
 msgid ""
 "With the producer application in place, it's time to implement the actual aggregator application,\n"
 "which will run the Kafka Streams pipeline.\n"
 "Create another project like so:"
-msgstr "Con la aplicación productora en su lugar, es hora de implementar la aplicación agregadora real, que ejecutará la canalización Kafka Streams. Cree otro proyecto como este"
+msgstr ""
+"Con la aplicación productora en su lugar, es momento de implementar la aplicación agregadora real,\n"
+"que ejecutará el flujo de Kafka Streams.\n"
+"Cree otro proyecto de la siguiente manera:"
 
 #: _guides/kafka-streams.adoc
-#, fuzzy
 msgid "This creates the `aggregator` project with the Quarkus extension for Kafka Streams and with the Jackson support for Quarkus REST (formerly RESTEasy Reactive)."
-msgstr "Esto crea el proyecto `aggregator` con la extensión Quarkus para Kafka Streams y con el soporte Jackson para Quarkus REST (antes RESTEasy Reactive)."
+msgstr "Esto crea el proyecto `aggregator` con la extensión de Quarkus para Kafka Streams y con el soporte de Jackson para Quarkus REST (anteriormente RESTEasy Reactive)."
 
 #: _guides/kafka-streams.adoc
-#, fuzzy
 msgid ""
 "If you already have your Quarkus project configured, you can add the `kafka-streams` extension\n"
 "to your project by running the following command in your project base directory:"
-msgstr "Si ya tiene configurado su proyecto Quarkus, puede añadir la extensión `kafka-streams` a su proyecto ejecutando el siguiente comando en el directorio base de su proyecto:"
+msgstr ""
+"Si ya tiene su proyecto Quarkus configurado, puede añadir la extensión `kafka-streams`\n"
+"a su proyecto ejecutando el siguiente comando en el directorio base del proyecto:"
 
 #. type: Plain text
 #: _guides/kafka-streams.adoc
-#, fuzzy
 msgid "This will add the following to your `pom.xml`:"
 msgstr "Esto añadirá lo siguiente a su `pom.xml`:"
 
 #. type: Title ===
 #: _guides/kafka-streams.adoc
-#, fuzzy, no-wrap
+#, no-wrap
 msgid "The Pipeline Implementation"
-msgstr "La implementación de la tubería"
+msgstr "Implementación del flujo"
 
 #: _guides/kafka-streams.adoc
-#, fuzzy
 msgid ""
 "Let's begin the implementation of the stream processing application by creating\n"
 "a few value objects for representing temperature measurements, weather stations and for keeping track of aggregated values."
-msgstr "Comencemos la implementación de la aplicación de procesamiento de flujos creando unos cuantos objetos de valor para representar las mediciones de temperatura, las estaciones meteorológicas y para llevar la cuenta de los valores agregados."
+msgstr ""
+"Comencemos la implementación de la aplicación de procesamiento de flujos creando\n"
+"algunos objetos de valor para representar las mediciones de temperatura, las estaciones meteorológicas y para llevar el registro de los valores agregados."
 
 #: _guides/kafka-streams.adoc
-#, fuzzy
 msgid ""
 "First, create the file `aggregator/src/main/java/org/acme/kafka/streams/aggregator/model/WeatherStation.java`,\n"
 "representing a weather station, with the following content:"
-msgstr "En primer lugar, cree el archivo `aggregator/src/main/java/org/acme/kafka/streams/aggregator/model/WeatherStation.java` , que representa una estación meteorológica, con el siguiente contenido:"
+msgstr ""
+"Primero, cree el archivo `aggregator/src/main/java/org/acme/kafka/streams/aggregator/model/WeatherStation.java`,'\n"
+"que representa una estación meteorológica, con el siguiente contenido:"
 
 #: _guides/kafka-streams.adoc
-#, fuzzy
 msgid "The `@RegisterForReflection` annotation instructs Quarkus to keep the class and its members during the native compilation. More details about the `@RegisterForReflection` annotation can be found on  the xref:writing-native-applications-tips.adoc#registerForReflection[native application tips] page."
-msgstr "La anotación `@RegisterForReflection` indica a Quarkus que mantenga la clase y sus miembros durante la compilación nativa. Se pueden encontrar más detalles sobre la anotación `@RegisterForReflection` en la página de  link:writing-native-applications-tips.html#registerForReflection[consejos para aplicaciones] nativas."
+msgstr "La anotación `@RegisterForReflection` indica a Quarkus que mantenga la clase y sus miembros durante la compilación nativa. Puede encontrar más detalles sobre la anotación `@RegisterForReflection` en la página xref:writing-native-applications-tips.html#registerForReflection[consejos para aplicaciones nativas]."
 
 #: _guides/kafka-streams.adoc
-#, fuzzy
 msgid ""
 "Then the file `aggregator/src/main/java/org/acme/kafka/streams/aggregator/model/TemperatureMeasurement.java`,\n"
 "representing temperature measurements for a given station:"
-msgstr "A continuación, el archivo `aggregator/src/main/java/org/acme/kafka/streams/aggregator/model/TemperatureMeasurement.java` , que representa las mediciones de temperatura de una estación determinada:"
+msgstr ""
+"Luego, cree el archivo `aggregator/src/main/java/org/acme/kafka/streams/aggregator/model/TemperatureMeasurement.java`,\n"
+"que representa las mediciones de temperatura de una estación determinada:"
 
 #: _guides/kafka-streams.adoc
-#, fuzzy
 msgid ""
 "And finally `aggregator/src/main/java/org/acme/kafka/streams/aggregator/model/Aggregation.java`,\n"
 "which will be used to keep track of the aggregated values while the events are processed in the streaming pipeline:"
-msgstr "Y, por último, `aggregator/src/main/java/org/acme/kafka/streams/aggregator/model/Aggregation.java` , que se utilizará para realizar un seguimiento de los valores agregados mientras se procesan los eventos en la canalización de flujo:"
+msgstr ""
+"Y finalmente, `aggregator/src/main/java/org/acme/kafka/streams/aggregator/model/Aggregation.java`,\n"
+"que se utilizará para llevar el seguimiento de los valores agregados mientras los eventos se procesan en el flujo de transmisión:"
 
 #: _guides/kafka-streams.adoc
-#, fuzzy
 msgid ""
 "Next, let's create the actual streaming query implementation itself in the `aggregator/src/main/java/org/acme/kafka/streams/aggregator/streams/TopologyProducer.java` file.\n"
 "All we need to do for that is to declare a CDI producer method which returns the Kafka Streams `Topology`;\n"
 "the Quarkus extension will take care of configuring, starting and stopping the actual Kafka Streams engine."
-msgstr "A continuación, vamos a crear la propia implementación de la consulta de flujo en el archivo `aggregator/src/main/java/org/acme/kafka/streams/aggregator/streams/TopologyProducer.java` . Todo lo que necesitamos para ello es declarar un método productor CDI que devuelva el Kafka Streams `Topology` ; la extensión Quarkus se encargará de configurar, iniciar y detener el motor Kafka Streams real."
+msgstr ""
+"A continuación, vamos a crear la implementación de la consulta de flujo en sí en el archivo `aggregator/src/main/java/org/acme/kafka/streams/aggregator/streams/TopologyProducer.java`.\n"
+"Todo lo que necesitamos hacer para ello es declarar un método productor CDI que devuelva la `Topology` de Kafka Streams;\n"
+"la extensión de Quarkus se encargará de configurar, iniciar y detener el motor real de Kafka Streams."
 
 #. type: Plain text
 #: _guides/kafka-streams.adoc
-#, fuzzy
 msgid "The `weather-stations` table is read into a `GlobalKTable`, representing the current state of each weather station"
-msgstr "La tabla `weather-stations` se lee en un `GlobalKTable`, que representa el estado actual de cada estación meteorológica"
+msgstr "La tabla `weather-stations` se lee en un `GlobalKTable`, representando el estado actual de cada estación meteorológica"
 
 #. type: Plain text
 #: _guides/kafka-streams.adoc
-#, fuzzy
 msgid "The `temperature-values` topic is read into a `KStream`; whenever a new message arrives to this topic, the pipeline will be processed for this measurement"
-msgstr "El tema `temperature-values` se lee en un `KStream`; cada vez que llegue un nuevo mensaje a este tema, se procesará la tubería para esta medición"
+msgstr "El tópico `temperature-values` se lee en un `KStream`; cada vez que llega un nuevo mensaje a este tópico, el flujo se procesará para esta medición"
 
 #. type: Plain text
 #: _guides/kafka-streams.adoc
-#, fuzzy
 msgid "The message from the `temperature-values` topic is joined with the corresponding weather station, using the topic's key (weather station id); the join result contains the data from the measurement and associated weather station message"
-msgstr "El mensaje del tema `temperature-values` se une con la estación meteorológica correspondiente, utilizando la clave del tema (ID de la estación meteorológica); el resultado de la unión contiene los datos de la medición y el mensaje de la estación meteorológica asociado"
+msgstr "El mensaje del tópico `temperature-values` se une con la estación meteorológica correspondiente, utilizando la clave del tópico (id de la estación meteorológica); el resultado de la unión contiene los datos de la medición y el mensaje asociado de la estación meteorológica"
 
 #. type: Plain text
 #: _guides/kafka-streams.adoc
-#, fuzzy
 msgid "The values are grouped by message key (the weather station id)"
-msgstr "Los valores se agrupan por la clave del mensaje (el identificador de la estación meteorológica)"
+msgstr "Los valores se agrupan por la clave del mensaje (el id de la estación meteorológica)"
 
 #. type: Plain text
 #: _guides/kafka-streams.adoc
-#, fuzzy
 msgid "Within each group, all the measurements of that station are aggregated, by keeping track of minimum and maximum values and calculating the average value of all measurements of that station (see the `Aggregation` type)"
-msgstr "Dentro de cada grupo, se agregan todas las mediciones de esa estación, llevando la cuenta de los valores mínimos y máximos y calculando el valor medio de todas las mediciones de esa estación (véase el tipo `Aggregation` )"
+msgstr "Dentro de cada grupo, todas las mediciones de esa estación se agregan, manteniendo un registro de los valores mínimos y máximos y calculando el valor promedio de todas las mediciones de esa estación (consulte el tipo `Aggregation`)"
 
 #. type: Plain text
 #: _guides/kafka-streams.adoc
-#, fuzzy
 msgid "The results of the pipeline are written out to the `temperatures-aggregated` topic"
-msgstr "Los resultados de la canalización se escriben en el tema `temperatures-aggregated`"
+msgstr "Los resultados del flujo se escriben en el tópico `temperatures-aggregated`"
 
 #: _guides/kafka-streams.adoc
-#, fuzzy
 msgid ""
 "The Kafka Streams extension is configured via the Quarkus configuration file `application.properties`.\n"
 "Create the file `aggregator/src/main/resources/application.properties` with the following contents:"
-msgstr "La extensión Kafka Streams se configura a través del archivo de configuración de Quarkus `application.properties` . Cree el archivo `aggregator/src/main/resources/application.properties` con el siguiente contenido:"
+msgstr ""
+"La extensión de Kafka Streams se configura mediante el archivo de configuración de Quarkus `application.properties`.\n"
+"Cree el archivo `aggregator/src/main/resources/application.properties` con el siguiente contenido:"
 
 #: _guides/kafka-streams.adoc
-#, fuzzy
 msgid ""
 "The options with the `quarkus.kafka-streams` prefix can be changed dynamically at application startup,\n"
 "e.g. via environment variables or system properties.\n"
 "`bootstrap-servers` and `application-server` are mapped to the Kafka Streams properties `bootstrap.servers` and `application.server`, respectively.\n"
 "`topics` is specific to Quarkus: the application will wait for all the given topics to exist before launching the Kafka Streams engine.\n"
 "This is to done to gracefully await the creation of topics that don't yet exist at application startup time."
-msgstr "Las opciones con el prefijo `quarkus.kafka-streams` pueden cambiarse dinámicamente al iniciar la aplicación, por ejemplo, mediante variables de entorno o propiedades del sistema. `bootstrap-servers` y `application-server` se asignan a las propiedades de Kafka Streams `bootstrap.servers` y `application.server` , respectivamente. `topics` es específica de Quarkus: la aplicación esperará a que existan todos los temas dados antes de lanzar el motor de Kafka Streams. Esto se hace para esperar con gracia la creación de temas que aún no existen en el momento de inicio de la aplicación."
+msgstr ""
+"Las opciones con el prefijo `quarkus.kafka-streams` se pueden cambiar dinámicamente al iniciar la aplicación,\n"
+"por ejemplo, mediante variables de entorno o propiedades del sistema.\n"
+"`bootstrap-servers` y `application-server` se asignan a las propiedades de Kafka Streams `bootstrap.servers` y `application.server`, respectivamente.\n"
+"`topics` es específico de Quarkus: la aplicación esperará a que existan todos los tópicos indicados antes de iniciar el motor de Kafka Streams.\n"
+"Esto se hace para esperar de manera ordenada la creación de tópicos que aún no existen al iniciar la aplicación."
 
 #. type: Plain text
 #: _guides/kafka-streams.adoc
-#, fuzzy
 msgid "Alternatively, you can use `kafka.bootstrap.servers` instead of `quarkus.kafka-streams.bootstrap-servers` as you did in the _generator_ project above."
-msgstr "Como alternativa, puede utilizar `kafka.bootstrap.servers` en lugar de `quarkus.kafka-streams.bootstrap-servers`, como hizo en el proyecto _del generador_ anterior."
+msgstr "Como alternativa, puede usar `kafka.bootstrap.servers` en lugar de `quarkus.kafka-streams.bootstrap-servers`, tal como se hizo en el proyecto _generator_ mencionado anteriormente."
 
 #: _guides/kafka-streams.adoc
-#, fuzzy
 msgid "Once you are ready to promote your application into production, consider changing the above configuration values. While `cache.max.bytes.buffering=10240` will move your records faster through the topology, the default value of `10485760` is more throughput-friendly. Also condider increasing `metadata.max.age.ms` from `500`, which will update cluster metadata quickly, but will generate a lot of redundant requests, to a value closer to the default of `300000`. A `commit.interval.ms` of `1000` is good for exactly-once processing, but might generate excessive load for  the default at-least-once processing with the default value of `30000`."
-msgstr "Una vez que esté listo para promocionar su aplicación a producción, considere la posibilidad de cambiar los valores de configuración anteriores. Mientras que `cache.max.bytes.buffering=10240` moverá sus registros más rápidamente a través de la topología, el valor por defecto de `10485760` es más respetuoso con el rendimiento. Considere también aumentar `metadata.max.age.ms` de `500` , que actualizará los metadatos del cluster rápidamente, pero generará muchas peticiones redundantes, a un valor más cercano al predeterminado de `300000` . Un valor de `commit.interval.ms` de `1000` es bueno para el procesamiento exactamente una vez, pero podría generar una carga excesiva para el procesamiento por defecto al menos una vez con el valor predeterminado de `30000` ."
+msgstr "Una vez que esté listo para promover su aplicación a producción, considere cambiar los valores de configuración anteriores. Mientras que `cache.max.bytes.buffering=10240` moverá sus registros más rápidamente a través de la topología, el valor predeterminado de `10485760` es más adecuado para el rendimiento de alto flujo. También considere aumentar `metadata.max.age.ms` desde `500`, lo cual actualizará rápidamente los metadatos del clúster, pero generará muchas solicitudes redundantes, a un valor más cercano al predeterminado de `300000`. Un `commit.interval.ms` de `1000` es bueno para el procesamiento *exactly-once*, pero podría generar una carga excesiva para el procesamiento *at-least-once* con el valor predeterminado de `30000`."
 
 #: _guides/kafka-streams.adoc
-#, fuzzy
 msgid ""
 "All the properties within the `kafka-streams` namespace are passed through as-is to the Kafka Streams engine.\n"
 "Changing their values requires a rebuild of the application."
-msgstr "Todas las propiedades del espacio de nombres `kafka-streams` se transmiten tal cual al motor Kafka Streams. Cambiar sus valores requiere una reconstrucción de la aplicación."
+msgstr ""
+"Todas las propiedades dentro del espacio de nombres `kafka-streams` se pasan tal cual al motor de Kafka Streams.\n"
+"Cambiar sus valores requiere una reconstrucción de la aplicación."
 
 #. type: Title ==
 #: _guides/kafka-streams.adoc
-#, fuzzy, no-wrap
+#, no-wrap
 msgid "Building and Running the Applications"
-msgstr "Construir y ejecutar las aplicaciones"
+msgstr "Construcción y ejecución de las aplicaciones"
 
 #. type: Plain text
 #: _guides/kafka-streams.adoc
-#, fuzzy
 msgid "We now can build the `producer` and `aggregator` applications:"
-msgstr "Ahora podemos construir las aplicaciones `producer` y `aggregator`:"
+msgstr "Ahora podemos compilar las aplicaciones `producer` y `aggregator`:"
 
 #: _guides/kafka-streams.adoc
-#, fuzzy
 msgid ""
 "Instead of running them directly on the host machine using the Quarkus dev mode,\n"
 "we're going to package them into container images and launch them via Docker Compose.\n"
 "This is done in order to demonstrate scaling the `aggregator` aggregation to multiple nodes later on."
-msgstr "En lugar de ejecutarlos directamente en la máquina anfitriona utilizando el modo dev de Quarkus, vamos a empaquetarlos en imágenes de contenedor y lanzarlos a través de Docker Compose. Esto se hace con el fin de demostrar el escalado de la agregación `aggregator` a múltiples nodos más adelante."
+msgstr ""
+"En lugar de ejecutarlas directamente en la máquina host utilizando el modo dev de Quarkus,\n"
+"vamos a empaquetarlas en imágenes de contenedor y lanzarlas mediante Docker Compose.\n"
+"Esto se hace con el fin de demostrar cómo escalar la agregación del `aggregator` a múltiples nodos más adelante."
 
 #: _guides/kafka-streams.adoc
-#, fuzzy
 msgid ""
 "The `Dockerfile` created by Quarkus by default needs one adjustment for the `aggregator` application in order to run the Kafka Streams pipeline.\n"
 "To do so, edit the file `aggregator/src/main/docker/Dockerfile.jvm` and replace the line `FROM fabric8/java-alpine-openjdk8-jre` with `FROM fabric8/java-centos-openjdk8-jdk`."
-msgstr "El `Dockerfile` creado por Quarkus por defecto necesita un ajuste para la aplicación `aggregator` con el fin de ejecutar la canalización Kafka Streams. Para ello, edite el archivo `aggregator/src/main/docker/Dockerfile.jvm` y sustituya la línea `FROM fabric8/java-alpine-openjdk8-jre` por `FROM fabric8/java-centos-openjdk8-jdk` ."
+msgstr ""
+"El `Dockerfile` creado por Quarkus por defecto necesita un ajuste para la aplicación `aggregator` con el fin de ejecutar el flujo de Kafka Streams.\n"
+"Para ello, edite el archivo `aggregator/src/main/docker/Dockerfile.jvm` y reemplace la línea `FROM fabric8/java-alpine-openjdk8-jre` por `FROM fabric8/java-centos-openjdk8-jdk`."
 
 #. type: Plain text
 #: _guides/kafka-streams.adoc
-#, fuzzy
 msgid "Next create a Docker Compose file (`docker-compose.yaml`) for spinning up the two applications as well as Apache Kafka and ZooKeeper like so:"
-msgstr "A continuación, cree un archivo Docker Compose ( `docker-compose.yaml`) para poner en marcha las dos aplicaciones, así como Apache Kafka y ZooKeeper, de esta manera:"
+msgstr "A continuación, cree un archivo Docker Compose ( `docker-compose.yaml`) para levantar las dos aplicaciones, así como Apache Kafka y ZooKeeper, de la siguiente manera:"
 
 #: _guides/kafka-streams.adoc
-#, fuzzy
 msgid ""
 "To launch all the containers, building the `producer` and `aggregator` container images,\n"
 "run `docker-compose up --build`."
-msgstr "Para lanzar todos los contenedores, construyendo las imágenes de contenedor `producer` y `aggregator` , ejecute `docker-compose up --build` ."
+msgstr ""
+"Para iniciar todos los contenedores, construyendo las imágenes de contenedor `producer` y `aggregator`,\n"
+"ejecute `docker-compose up --build`."
 
 #. type: Plain text
 #: _guides/kafka-streams.adoc
-#, fuzzy
 msgid "Instead of `QUARKUS_KAFKA_STREAMS_BOOTSTRAP_SERVERS`, you can use `KAFKA_BOOTSTRAP_SERVERS`."
-msgstr "En lugar de `QUARKUS_KAFKA_STREAMS_BOOTSTRAP_SERVERS`, puede utilizar `KAFKA_BOOTSTRAP_SERVERS`."
+msgstr "En lugar de `QUARKUS_KAFKA_STREAMS_BOOTSTRAP_SERVERS`, puede usar `KAFKA_BOOTSTRAP_SERVERS`."
 
 #. type: Plain text
 #: _guides/kafka-streams.adoc
-#, fuzzy
 msgid "You should see log statements from the `producer` application about messages being sent to the \"temperature-values\" topic."
-msgstr "Debería ver las declaraciones de registro de la aplicación `producer` sobre los mensajes que se envían al tema \"temperature-values\"."
+msgstr "Debería ver declaraciones de registro de la aplicación `producer` sobre los mensajes enviados al tópico \"temperature-values\"."
 
 #: _guides/kafka-streams.adoc
-#, fuzzy
 msgid ""
 "Now run an instance of the _debezium/tooling_ image, attaching to the same network all the other containers run in.\n"
 "This image provides several useful tools such as _kafkacat_ and _httpie_:"
-msgstr "Ahora ejecute una instancia de la imagen _debezium/tooling_ , conectándose a la misma red en la que se ejecutan todos los demás contenedores. Esta imagen proporciona varias herramientas útiles como _kafkacat_ y _httpie_ :"
+msgstr ""
+"Ahora ejecute una instancia de la imagen _debezium/tooling_, conectándola a la misma red en la que se ejecutan todos los demás contenedores.\n"
+"Esta imagen proporciona varias herramientas útiles, como _kafkacat_ y _httpie_:"
 
 #. type: Plain text
 #: _guides/kafka-streams.adoc
-#, fuzzy
 msgid "Within the tooling container, run _kafkacat_ to examine the results of the streaming pipeline:"
-msgstr "Dentro del contenedor de herramientas, ejecute _kafkacat_ para examinar los resultados de la tubería de streaming:"
+msgstr "Dentro del contenedor de herramientas, ejecute _kafkacat_ para examinar los resultados de la transmisión del flujo:"
 
 #: _guides/kafka-streams.adoc
-#, fuzzy
 msgid ""
 "You should see new values arrive as the producer continues to emit temperature measurements,\n"
 "each value on the outbound topic showing the minimum, maximum and average temperature values of the represented weather station."
-msgstr "Debería ver llegar nuevos valores a medida que el productor siga emitiendo mediciones de temperatura, cada valor en el tema de salida mostrará los valores de temperatura mínima, máxima y media de la estación meteorológica representada."
+msgstr ""
+"Debería ver llegar nuevos valores a medida que el productor continúa emitiendo mediciones de temperatura,\n"
+"cada valor en el tópico de salida mostrando los valores mínimo, máximo y promedio de temperatura de la estación meteorológica representada."
 
 #. type: Title ==
 #: _guides/kafka-streams.adoc
-#, fuzzy, no-wrap
+#, no-wrap
 msgid "Interactive Queries"
 msgstr "Consultas interactivas"
 
 #: _guides/kafka-streams.adoc
-#, fuzzy
 msgid ""
 "Subscribing to the `temperatures-aggregated` topic is a great way to react to any new temperature values.\n"
 "It's a bit wasteful though if you're just interested in the latest aggregated value for a given weather station.\n"
@@ -488,373 +488,367 @@ msgid ""
 "they let you directly query the underlying state store of the pipeline for the value associated to a given key.\n"
 "By exposing a simple REST endpoint which queries the state store,\n"
 "the latest aggregation result can be retrieved without having to subscribe to any Kafka topic."
-msgstr "Suscribirse al tema `temperatures-aggregated` es una buena forma de reaccionar ante cualquier nuevo valor de temperatura. Sin embargo, es un poco inútil si sólo está interesado en el último valor agregado de una estación meteorológica determinada. Aquí es donde brillan las consultas interactivas de Kafka Streams: le permiten consultar directamente el almacén de estado subyacente de la canalización para obtener el valor asociado a una clave determinada. Al exponer un simple punto final REST que consulta el almacén de estado, se puede recuperar el último resultado de agregación sin tener que suscribirse a ningún tema Kafka."
+msgstr ""
+"Suscribirse al tópico `temperatures-aggregated` es una excelente manera de reaccionar ante cualquier nuevo valor de temperatura.\n"
+"Sin embargo, es un poco ineficiente si solo le interesa el último valor agregado de una estación meteorológica específica.\n"
+"Aquí es donde las consultas interactivas de Kafka Streams destacan:\n"
+"permiten consultar directamente el almacén de estado subyacente del flujo para obtener el valor asociado a una clave determinada.\n"
+"Al exponer un endpoint REST simple que consulte el almacén de estado,\n"
+"se puede recuperar el resultado de la última agregación sin necesidad de suscribirse a ningún tópico de Kafka."
 
 #. type: Plain text
 #: _guides/kafka-streams.adoc
-#, fuzzy
 msgid "Let's begin by creating a new class `InteractiveQueries` in the file `aggregator/src/main/java/org/acme/kafka/streams/aggregator/streams/InteractiveQueries.java`:"
 msgstr "Comencemos creando una nueva clase `InteractiveQueries` en el archivo `aggregator/src/main/java/org/acme/kafka/streams/aggregator/streams/InteractiveQueries.java`:"
 
 #. type: Plain text
 #: _guides/kafka-streams.adoc
-#, fuzzy
 msgid "one more method to the `KafkaStreamsPipeline` class which obtains the current state for a given key:"
-msgstr "un método más a la clase `KafkaStreamsPipeline` que obtiene el estado actual para una clave determinada:"
+msgstr "un método más para la clase `KafkaStreamsPipeline` que obtiene el estado actual para una clave determinada:"
 
 #. type: Plain text
 #: _guides/kafka-streams.adoc
-#, fuzzy
 msgid "A value for the given station id was found, so that value will be returned"
-msgstr "Se ha encontrado un valor para el identificador de estación dado, por lo que se devolverá ese valor"
+msgstr "Se encontró un valor para la estación indicada, por lo que se devolverá ese valor"
 
 #. type: Plain text
 #: _guides/kafka-streams.adoc
-#, fuzzy
 msgid "No value was found, either because a non-existing station was queried or no measurement exists yet for the given station"
-msgstr "No se ha encontrado ningún valor, ya sea porque se ha consultado una estación inexistente o porque todavía no existe ninguna medición para la estación en cuestión"
+msgstr "No se ha encontrado ningún valor, ya sea porque se ha consultado una estación inexistente o porque todavía no existe ninguna medición para la estación indicada"
 
 #. type: Plain text
 #: _guides/kafka-streams.adoc
-#, fuzzy
 msgid "Also create the method's return type in the file `aggregator/src/main/java/org/acme/kafka/streams/aggregator/streams/GetWeatherStationDataResult.java`:"
-msgstr "Cree también el tipo de retorno del método en el archivo `aggregator/src/main/java/org/acme/kafka/streams/aggregator/streams/GetWeatherStationDataResult.java`:"
+msgstr "También cree el tipo de retorno del método en el archivo `aggregator/src/main/java/org/acme/kafka/streams/aggregator/streams/GetWeatherStationDataResult.java`:"
 
 #: _guides/kafka-streams.adoc
-#, fuzzy
 msgid ""
 "Also create `aggregator/src/main/java/org/acme/kafka/streams/aggregator/model/WeatherStationData.java`,\n"
 "which represents the actual aggregation result for a weather station:"
-msgstr "Cree también `aggregator/src/main/java/org/acme/kafka/streams/aggregator/model/WeatherStationData.java` , que representa el resultado real de la agregación para una estación meteorológica:"
+msgstr ""
+"También cree `aggregator/src/main/java/org/acme/kafka/streams/aggregator/model/WeatherStationData.java`,\n"
+"que representa el resultado de agregación actual de una estación meteorológica:"
 
 #: _guides/kafka-streams.adoc
-#, fuzzy
 msgid ""
 "We now can add a simple REST endpoint (`aggregator/src/main/java/org/acme/kafka/streams/aggregator/rest/WeatherStationEndpoint.java`),\n"
 "which invokes `getWeatherStationData()` and returns the data to the client:"
-msgstr "Ahora podemos añadir un simple punto final REST ( `aggregator/src/main/java/org/acme/kafka/streams/aggregator/rest/WeatherStationEndpoint.java` ), que invoca a `getWeatherStationData()` y devuelve los datos al cliente:"
+msgstr ""
+"Ahora podemos agregar una ruta REST simple (`aggregator/src/main/java/org/acme/kafka/streams/aggregator/rest/WeatherStationEndpoint.java`),\n"
+"que invoque `getWeatherStationData()` y devuelva los datos al cliente:"
 
 #. type: Plain text
 #: _guides/kafka-streams.adoc
-#, fuzzy
 msgid "Depending on whether a value was obtained, either return that value or a 404 response"
-msgstr "Dependiendo de si se ha obtenido un valor, devuelve ese valor o una respuesta 404"
+msgstr "Dependiendo de si se obtuvo un valor, devuelva ese valor o una respuesta 404"
 
 #. type: Plain text
 #: _guides/kafka-streams.adoc
-#, fuzzy
 msgid "With this code in place, it's time to rebuild the application and the `aggregator` service in Docker Compose:"
 msgstr "Con este código en su lugar, es hora de reconstruir la aplicación y el servicio `aggregator` en Docker Compose:"
 
 #: _guides/kafka-streams.adoc
-#, fuzzy
 msgid ""
 "This will rebuild the `aggregator` container and restart its service.\n"
 "Once that's done, you can invoke the service's REST API to obtain the temperature data for one of the existing stations.\n"
 "To do so, you can use `httpie` in the tooling container launched before:"
-msgstr "Esto reconstruirá el contenedor `aggregator` y reiniciará su servicio. Una vez hecho esto, podrá invocar la API REST del servicio para obtener los datos de temperatura de una de las estaciones existentes. Para ello, puede utilizar `httpie` en el contenedor de herramientas lanzado anteriormente:"
+msgstr ""
+"Esto reconstruirá el contenedor `aggregator` y reiniciará el servicio.\n"
+"Una vez completado, puede invocar la API REST del servicio para obtener los datos de temperatura de una de las estaciones existentes.\n"
+"Para ello, puede usar `httpie` en el contenedor de herramientas que se lanzó anteriormente:"
 
 #. type: Title ==
 #: _guides/kafka-streams.adoc
-#, fuzzy, no-wrap
+#, no-wrap
 msgid "Scaling Out"
-msgstr "Escalada"
+msgstr "Escalado horizontal"
 
 #: _guides/kafka-streams.adoc
-#, fuzzy
 msgid ""
 "A very interesting trait of Kafka Streams applications is that they can be scaled out,\n"
 "i.e. the load and state can be distributed amongst multiple application instances running the same pipeline.\n"
 "Each node will then contain a subset of the aggregation results,\n"
 "but Kafka Streams provides you with https://kafka.apache.org/22/documentation/streams/developer-guide/interactive-queries.html#querying-remote-state-stores-for-the-entire-app[an API] to obtain the information which node is hosting a given key.\n"
 "The application can then either fetch the data directly from the other instance, or simply point the client to the location of that other node."
-msgstr "Un rasgo muy interesante de las aplicaciones Kafka Streams es que pueden escalarse, es decir, la carga y el estado pueden distribuirse entre varias instancias de la aplicación que ejecuten el mismo pipeline. Cada nodo contendrá entonces un subconjunto de los resultados de la agregación, pero Kafka Streams le proporciona link:https://kafka.apache.org/22/documentation/streams/developer-guide/interactive-queries.html#querying-remote-state-stores-for-the-entire-app[una API] para obtener la información de qué nodo alberga una clave determinada. La aplicación puede entonces obtener los datos directamente de la otra instancia, o simplemente dirigir al cliente a la ubicación de ese otro nodo."
+msgstr ""
+"Una característica muy interesante de las aplicaciones Kafka Streams es que pueden escalarse horizontalmente,\n"
+"es decir, la carga y el estado pueden distribuirse entre múltiples instancias de la aplicación que ejecutan el mismo flujo.\n"
+"Cada nodo contendrá entonces un subconjunto de los resultados de agregación,\n"
+"pero Kafka Streams le proporciona https://kafka.apache.org/22/documentation/streams/developer-guide/interactive-queries.html#querying-remote-state-stores-for-the-entire-app[una API] para obtener información sobre qué nodo aloja una clave determinada.\n"
+"La aplicación puede entonces recuperar los datos directamente de la otra instancia, o simplemente indicar al cliente la ubicación de ese otro nodo."
 
 #. type: Plain text
 #: _guides/kafka-streams.adoc
-#, fuzzy
 msgid "Launching multiple instances of the `aggregator` application will make look the overall architecture like so:"
-msgstr "El lanzamiento de múltiples instancias de la aplicación `aggregator` hará que la arquitectura general se vea así:"
+msgstr "Lanzar múltiples instancias de la aplicación `aggregator` hará que la arquitectura general se vea así:"
 
 #. type: Plain text
 #: _guides/kafka-streams.adoc
-#, fuzzy
 msgid "The `InteractiveQueries` class must be adjusted slightly for this distributed architecture:"
-msgstr "La clase `InteractiveQueries` debe ajustarse ligeramente para esta arquitectura distribuida:"
+msgstr "La clase `InteractiveQueries` debe ajustarse ligeramente para adaptarse a esta arquitectura distribuida:"
 
 #. type: Plain text
 #: _guides/kafka-streams.adoc
-#, fuzzy
 msgid "The streams metadata for the given weather station id is obtained"
-msgstr "Se obtienen los metadatos de los flujos para el id de la estación meteorológica dada"
+msgstr "Se obtiene la metadata de los flujos para el id de estación meteorológica dado"
 
 #. type: Plain text
 #: _guides/kafka-streams.adoc
-#, fuzzy
 msgid "The given key (weather station id) is maintained by the local application node, i.e. it can answer the query itself"
-msgstr "La clave dada (ID de la estación meteorológica) es mantenida por el nodo de la aplicación local, es decir, puede responder a la consulta por sí mismo"
+msgstr "La clave dada (ID de la estación meteorológica) es gestionada por el nodo de la aplicación local, es decir, puede responder la consulta por sí mismo"
 
 #. type: Plain text
 #: _guides/kafka-streams.adoc
-#, fuzzy
 msgid "The given key is maintained by another application node; in this case the information about that node (host and port) will be returned"
-msgstr "La clave dada es mantenida por otro nodo de aplicación; en este caso se devolverá la información sobre ese nodo (host y puerto)"
+msgstr "La clave dada es gestionada por otro nodo de aplicación; en este caso se devolverá la información sobre ese nodo (host y puerto)"
 
 #. type: Plain text
 #: _guides/kafka-streams.adoc
-#, fuzzy
 msgid "The `getMetaData()` method is added to provide callers with a list of all the nodes in the application cluster."
-msgstr "El método `getMetaData()` se añade para proporcionar a los llamantes una lista de todos los nodos del clúster de la aplicación."
+msgstr "El método `getMetaData()` es agregado para proporcionar a los clientes una lista de todos los nodos del clúster de la aplicación."
 
 #. type: Plain text
 #: _guides/kafka-streams.adoc
-#, fuzzy
 msgid "The `GetWeatherStationDataResult` type must be adjusted accordingly:"
-msgstr "El tipo de `GetWeatherStationDataResult` debe ajustarse en consecuencia:"
+msgstr "El tipo `GetWeatherStationDataResult` debe ajustarse en consecuencia:"
 
 #: _guides/kafka-streams.adoc
-#, fuzzy
 msgid ""
 "Also, the return type for `getMetaData()` must be defined\n"
 "(`aggregator/src/main/java/org/acme/kafka/streams/aggregator/streams/PipelineMetadata.java`):"
-msgstr "Además, debe definirse el tipo de retorno para `getMetaData()` ( `aggregator/src/main/java/org/acme/kafka/streams/aggregator/streams/PipelineMetadata.java` ):"
+msgstr ""
+"Además, se debe definir el tipo de retorno para `getMetaData()`\n"
+"(`aggregator/src/main/java/org/acme/kafka/streams/aggregator/streams/PipelineMetadata.java` ):"
 
 #. type: Plain text
 #: _guides/kafka-streams.adoc
-#, fuzzy
 msgid "Lastly, the REST endpoint class must be updated:"
-msgstr "Por último, hay que actualizar la clase del punto final REST:"
+msgstr "Por último, se debe actualizar la clase del endpoint REST:"
 
 #. type: Plain text
 #: _guides/kafka-streams.adoc
-#, fuzzy
 msgid "The data was found locally, so return it"
-msgstr "Los datos fueron encontrados localmente, así que devuélvelos"
+msgstr "Los datos se encontraron localmente, por lo que se devuelven"
 
 #. type: Plain text
 #: _guides/kafka-streams.adoc
-#, fuzzy
 msgid "The data is maintained by another node, so reply with a redirect (HTTP status code 303) if the data for the given key is stored on one of the other nodes."
-msgstr "Los datos son mantenidos por otro nodo, así que responde con una redirección (código de estado HTTP 303) si los datos para la clave dada están almacenados en uno de los otros nodos."
+msgstr "Los datos son gestionados por otro nodo, por lo que se debe responder con una redirección (código de estado HTTP 303) si los datos de la clave dada están almacenados en uno de los otros nodos."
 
 #. type: Plain text
 #: _guides/kafka-streams.adoc
-#, fuzzy
 msgid "No data was found for the given weather station id"
-msgstr "No se han encontrado datos para la estación meteorológica indicada"
+msgstr "No se encontraron datos para el ID de estación meteorológica proporcionado"
 
 #. type: Plain text
 #: _guides/kafka-streams.adoc
-#, fuzzy
 msgid "Exposes information about all the hosts forming the application cluster"
-msgstr "Expone información sobre todos los hosts que forman el cluster de aplicaciones"
+msgstr "Expone información sobre todos los hosts que conforman el cluster de la aplicacion"
 
 #: _guides/kafka-streams.adoc
-#, fuzzy
 msgid ""
 "Now stop the `aggregator` service again and rebuild it.\n"
 "Then let's spin up three instances of it:"
-msgstr "Ahora detenga de nuevo el servicio `aggregator` y reconstrúyalo. A continuación, pongamos en marcha tres instancias del mismo:"
+msgstr ""
+"Ahora detenga de nuevo el servicio `aggregator` y reconstrúyalo.\n"
+"Luego, inicie las tres instancias del mismo:"
 
 #: _guides/kafka-streams.adoc
-#, fuzzy
 msgid ""
 "When invoking the REST API on any of the three instances, it might either be\n"
 "that the aggregation for the requested weather station id is stored locally on the node receiving the query,\n"
 "or it could be stored on one of the other two nodes."
-msgstr "Al invocar la API REST en cualquiera de las tres instancias, puede ocurrir que la agregación para el id de la estación meteorológica solicitada se almacene localmente en el nodo que recibe la consulta, o bien que se almacene en uno de los otros dos nodos."
+msgstr ""
+"Al invocar la API REST en cualquiera de las tres instancias, puede ocurrir\n"
+"que la agregación para el ID de la estación meteorológica solicitada este almacenada localmente en el nodo que recibe la consulta,\n"
+"o bien que esté almacenada en uno de los otros dos nodos."
 
 #: _guides/kafka-streams.adoc
-#, fuzzy
 msgid ""
 "As the load balancer of Docker Compose will distribute requests to the `aggregator` service in a round-robin fashion,\n"
 "we'll invoke the actual nodes directly.\n"
 "The application exposes information about all the host names via REST:"
-msgstr "Como el equilibrador de carga de Docker Compose distribuirá las solicitudes al servicio `aggregator` de forma rotatoria, invocaremos directamente a los nodos reales. La aplicación expone información sobre todos los nombres de host a través de REST:"
+msgstr ""
+"Como el balanceador de carga de Docker Compose distribuirá las solicitudes al servicio `aggregator` de manera round-robin,\n"
+"invocaremos los nodos reales directamente.\n"
+"La aplicación expone información sobre todos los nombres de host mediante REST:"
 
 #: _guides/kafka-streams.adoc
-#, fuzzy
 msgid ""
 "Retrieve the data from one of the three hosts shown in the response\n"
 "(your actual host names will differ):"
-msgstr "Recupere los datos de uno de los tres hosts mostrados en la respuesta (sus nombres de host reales serán diferentes):"
+msgstr ""
+"Recupere los datos de uno de los tres hosts mostrados en la respuesta\n"
+"(sus nombres de host reales serán diferentes):"
 
 #. type: Plain text
 #: _guides/kafka-streams.adoc
-#, fuzzy
 msgid "If that node holds the data for key \"1\", you'll get a response like this:"
-msgstr "Si ese nodo contiene los datos de la clave \"1\", obtendrás una respuesta como ésta:"
+msgstr "Si ese nodo contiene los datos de la clave \"1\", obtendrás una respuesta como esta:"
 
 #. type: Plain text
 #: _guides/kafka-streams.adoc
-#, fuzzy
 msgid "Otherwise, the service will send a redirect:"
-msgstr "En caso contrario, el servicio enviará una redirección:"
+msgstr "De lo contrario, el servicio enviará una redirección:"
 
 #. type: Plain text
 #: _guides/kafka-streams.adoc
-#, fuzzy
 msgid "You can also have _httpie_ automatically follow the redirect by passing the `--follow option`:"
-msgstr "También puede hacer que _httpie_ siga automáticamente la redirección pasando el `--follow option`:"
+msgstr "También puede hacer que _httpie_ siga automáticamente la redirección pasando la opción `--follow`:"
 
 #. type: Title ==
 #: _guides/kafka-streams.adoc
-#, fuzzy, no-wrap
+#, no-wrap
 msgid "Running Natively"
-msgstr "Funcionando de forma nativa"
+msgstr "Ejecución Nativa"
 
 #: _guides/kafka-streams.adoc
-#, fuzzy
 msgid ""
 "The Quarkus extension for Kafka Streams enables the execution of stream processing applications\n"
 "natively via GraalVM without further configuration."
-msgstr "La extensión Quarkus para Kafka Streams permite la ejecución de aplicaciones de procesamiento de flujos de forma nativa a través de GraalVM sin necesidad de configuración adicional."
+msgstr ""
+"La extensión de Quarkus para Kafka Streams permite la ejecución de aplicaciones de procesamiento de flujos\n"
+"de manera nativa mediante GraalVM sin necesidad de configuración adicional."
 
 #: _guides/kafka-streams.adoc
-#, fuzzy
 msgid ""
 "To run both the `producer` and `aggregator` applications in native mode,\n"
 "the Maven builds can be executed using `-Dnative`:"
-msgstr "Para ejecutar las aplicaciones `producer` y `aggregator` en modo nativo, las compilaciones de Maven pueden ejecutarse utilizando `-Dnative` :"
+msgstr ""
+"Para ejecutar las aplicaciones `producer` y `aggregator` en modo nativo,\n"
+"las compilaciones de Maven pueden ejecutarse usando `-Dnative`:"
 
 #. type: Plain text
 #: _guides/kafka-streams.adoc
-#, fuzzy
 msgid "Now create an environment variable named `QUARKUS_MODE` and with value set to \"native\":"
-msgstr "Ahora cree una variable de entorno llamada `QUARKUS_MODE` y con el valor establecido como \"nativo\":"
+msgstr "Ahora cree una variable de entorno llamada `QUARKUS_MODE` y con su valor establecido en \"native\":"
 
 #: _guides/kafka-streams.adoc
-#, fuzzy
 msgid ""
 "This is used by the Docker Compose file to use the correct `Dockerfile` when building the `producer` and `aggregator` images.\n"
 "The Kafka Streams application can work with less than 50 MB RSS in native mode.\n"
 "To do so, add the `Xmx` option to the program invocation in `aggregator/src/main/docker/Dockerfile.native`:"
-msgstr "Esto lo utiliza el archivo Docker Compose para utilizar el `Dockerfile` correcto al construir las imágenes `producer` y `aggregator` . La aplicación Kafka Streams puede trabajar con menos de 50 MB de RSS en modo nativo. Para ello, añada la opción `Xmx` a la invocación del programa en `aggregator/src/main/docker/Dockerfile.native` :"
+msgstr ""
+"Esto lo utiliza el archivo Docker Compose para emplear el `Dockerfile` correcto al construir las imágenes de `producer` y `aggregator`.\n"
+"La aplicación Kafka Streams puede funcionar con menos de 50 MB de RSS en modo nativo.\n"
+"Para ello, agregue la opción `Xmx` al invocar el programa en `aggregator/src/main/docker/Dockerfile.native`:"
 
 #: _guides/kafka-streams.adoc
-#, fuzzy
 msgid ""
 "Now start Docker Compose as described above\n"
 "(don't forget to rebuild the container images)."
-msgstr "Ahora inicie Docker Compose como se ha descrito anteriormente (no olvide reconstruir las imágenes del contenedor)."
+msgstr ""
+"Ahora inicie Docker Compose como se describió anteriormente\n"
+"(no olvide reconstruir las imágenes de los contenedores)."
 
 #. type: Title ==
 #: _guides/kafka-streams.adoc
-#, fuzzy, no-wrap
+#, no-wrap
 msgid "Kafka Streams Health Checks"
-msgstr "Comprobaciones de salud de Kafka Streams"
+msgstr "Verificación del estado de Kafka Streams"
 
 #. type: Plain text
 #: _guides/kafka-streams.adoc
-#, fuzzy
 msgid "If you are using the `quarkus-smallrye-health` extension, `quarkus-kafka-streams` will automatically add:"
-msgstr "Si utiliza la extensión `quarkus-smallrye-health`, `quarkus-kafka-streams` se añadirá automáticamente:"
+msgstr "Si está utilizando la extensión `quarkus-smallrye-health`, `quarkus-kafka-streams` añadirá automáticamente:"
 
 #. type: Plain text
 #: _guides/kafka-streams.adoc
-#, fuzzy
 msgid "a readiness health check to validate that all topics declared in the `quarkus.kafka-streams.topics` property are created,"
-msgstr "una comprobación de disponibilidad para validar que se han creado todos los temas declarados en la propiedad `quarkus.kafka-streams.topics`,"
+msgstr "una comprobación de disponibilidad para validar que se han creado todos los tópicos declarados en la propiedad `quarkus.kafka-streams.topics`,"
 
 #. type: Plain text
 #: _guides/kafka-streams.adoc
-#, fuzzy
 msgid "a liveness health check based on the Kafka Streams state."
-msgstr "una comprobación de la salud de la vida basada en el estado de Kafka Streams."
+msgstr "una comprobación de funcionamiento basada en el estado de Kafka Streams."
 
 #. type: Plain text
 #: _guides/kafka-streams.adoc
-#, fuzzy
 msgid "So when you access the `/q/health` endpoint of your application you will have information about the state of the Kafka Streams and the available and/or missing topics."
-msgstr "Así, cuando acceda al endpoint `/q/health` de su aplicación tendrá información sobre el estado de los Streams de Kafka y los temas disponibles y/o faltantes."
+msgstr "Así, cuando acceda a la ruta `/q/health` de su aplicación, obtendrá información sobre el estado de Kafka Streams y los tópicos disponibles y/o faltantes."
 
 #. type: Plain text
 #: _guides/kafka-streams.adoc
-#, fuzzy
 msgid "This is an example of when the status is `DOWN`:"
 msgstr "Este es un ejemplo de cuando el estado es `DOWN`:"
 
 #. type: Plain text
 #: _guides/kafka-streams.adoc
-#, fuzzy
 msgid "Liveness health check. Also available at `/q/health/live` endpoint."
-msgstr "Comprobación de la salud de la vida. También disponible en `/q/health/live` endpoint."
+msgstr "Comprobación del funcionamiento. También disponible en la ruta `/q/health/live`."
 
 #. type: Plain text
 #: _guides/kafka-streams.adoc
-#, fuzzy
 msgid "Readiness health check. Also available at `/q/health/ready` endpoint."
-msgstr "Comprobación del estado de preparación. También disponible en `/q/health/ready` endpoint."
+msgstr "Comprobación del estado de preparación. También disponible en la ruta `/q/health/ready`."
 
 #. type: Plain text
 #: _guides/kafka-streams.adoc
-#, fuzzy
 msgid "So as you can see, the status is `DOWN` as soon as one of the `quarkus.kafka-streams.topics` is missing or the Kafka Streams `state` is not `RUNNING`."
-msgstr "Así que, como puede ver, el estado es `DOWN` en cuanto falta uno de los `quarkus.kafka-streams.topics` o el Kafka Streams `state` no es `RUNNING`."
+msgstr "Así que, como puede ver, el estado es `DOWN` cuando falta uno de los `quarkus.kafka-streams.topics` o el `state` de Kafka Streams no es `RUNNING`."
 
 #: _guides/kafka-streams.adoc
-#, fuzzy
 msgid ""
 "If no topics are available, the `available_topics` key will not be present in the `data` field of the `Kafka Streams topics health check`.\n"
 "As well as if no topics are missing, the `missing_topics` key will not be present in the `data` field of the `Kafka Streams topics health check`."
-msgstr "Si no hay temas disponibles, la clave `available_topics` no estará presente en el campo `data` del `Kafka Streams topics health check` . Así como si no hay temas, la clave `missing_topics` no estará presente en el campo `data` del `Kafka Streams topics health check` ."
+msgstr ""
+"Si no hay tópicos disponibles, la clave `available_topics` no estará presente en el campo `data` de la `comprobación del estado de los tópicos de Kafka Streams`.\n"
+"Asimismo, si no falta ningún tópico, la clave `missing_topics` no estará presente en el campo `data` de la `comprobación del estado de los tópicos de Kafka Streams`."
 
 #. type: Plain text
 #: _guides/kafka-streams.adoc
-#, fuzzy
 msgid "You can of course disable the health check of the `quarkus-kafka-streams` extension by setting the `quarkus.kafka-streams.health.enabled` property to `false` in your `application.properties`."
-msgstr "Por supuesto, puede desactivar la comprobación de la salud de la extensión `quarkus-kafka-streams` estableciendo la propiedad `quarkus.kafka-streams.health.enabled` a `false` en su `application.properties`."
+msgstr "Por supuesto, puede desactivar la comprobación de estado de la extensión `quarkus-kafka-streams` estableciendo la propiedad `quarkus.kafka-streams.health.enabled` en `false` en su `application.properties`."
 
 #. type: Plain text
 #: _guides/kafka-streams.adoc
-#, fuzzy
 msgid "Obviously you can create your liveness and readiness probes based on the respective endpoints `/q/health/live` and `/q/health/ready`."
-msgstr "Evidentemente, puede crear sus sondas de capacidad de respuesta y de preparación basadas en los respectivos puntos finales `/q/health/live` y `/q/health/ready`."
+msgstr "Obviamente, puede crear sus sondas de disponibilidad y de preparación basadas en las respectivas rutas `/q/health/live` y `/q/health/ready`."
 
 #. type: Title ===
 #: _guides/kafka-streams.adoc
-#, fuzzy, no-wrap
+#, no-wrap
 msgid "Liveness health check"
-msgstr "Comprobación de la salud de la vida"
+msgstr "Comprobación del estado (Liveness)"
 
 #. type: Plain text
 #: _guides/kafka-streams.adoc
-#, fuzzy
 msgid "Here is an example of the liveness check:"
-msgstr "Este es un ejemplo de la comprobación de la vitalidad:"
+msgstr "Aquí hay un ejemplo de la comprobación de estado (liveness):"
 
 #. type: Plain text
 #: _guides/kafka-streams.adoc
-#, fuzzy
 msgid "The `state` is coming from the `KafkaStreams.State` enum."
 msgstr "El `state` viene del enum `KafkaStreams.State`."
 
 #. type: Title ===
 #: _guides/kafka-streams.adoc
-#, fuzzy, no-wrap
+#, no-wrap
 msgid "Readiness health check"
-msgstr "Comprobación del estado de preparación"
+msgstr "Comprobación del estado de preparación (readiness)"
 
 #. type: Plain text
 #: _guides/kafka-streams.adoc
-#, fuzzy
 msgid "Here is an example of the readiness check:"
-msgstr "Este es un ejemplo de la comprobación de la preparación:"
+msgstr "Aquí hay un ejemplo de la comprobación de preparación (readiness):"
 
 #. type: Title ==
 #: _guides/kafka-streams.adoc
-#, fuzzy, no-wrap
+#, no-wrap
 msgid "Going Further"
 msgstr "Ir más allá"
 
 #: _guides/kafka-streams.adoc
-#, fuzzy
 msgid ""
 "This guide has shown how you can build stream processing applications using Quarkus and the Kafka Streams APIs,\n"
 "both in JVM and native modes.\n"
 "For running your KStreams application in production, you could also add health checks and metrics for the data pipeline.\n"
 "Refer to the Quarkus guides on xref:telemetry-micrometer.adoc[Micrometer], xref:smallrye-metrics.adoc[SmallRye Metrics], and xref:smallrye-health.adoc[SmallRye Health] to learn more."
-msgstr "Esta guía ha mostrado cómo puede construir aplicaciones de procesamiento de flujos utilizando Quarkus y las APIs de Kafka Streams, tanto en modo JVM como nativo. Para ejecutar su aplicación KStreams en producción, también podría añadir comprobaciones de salud y métricas para la canalización de datos. Consulte las guías de Quarkus sobre xref:telemetry-micrometer.adoc[Micrometer] , xref:smallrye-metrics.adoc[SmallRye Metrics] y xref:smallrye-health.adoc[SmallRye] Health para obtener más información."
+msgstr ""
+"Esta guía ha mostrado cómo puede construir aplicaciones de procesamiento de flujos utilizando Quarkus y las APIs de Kafka Streams,\n"
+"tanto en modo JVM como nativo.\n"
+"Para ejecutar su aplicación KStreams en producción, también podría añadir comprobaciones de salud y métricas para el flujo de datos.\n"
+"Consulte las guías de Quarkus sobre xref:telemetry-micrometer.adoc[Micrometer], xref:smallrye-metrics.adoc[SmallRye Metrics] y xref:smallrye-health.adoc[SmallRye Health] para obtener más información."
 
 #. type: Title ==
 #: _guides/kafka-streams.adoc


### PR DESCRIPTION
### Summary
This PR update the Spanish translation for the Kafka Streams guide.

### Changes
- Updated file `l10n/po/es_ES/_guides/kafka-streams.adoc.po`.

Closes #253 